### PR TITLE
camera_frame doesn't exist

### DIFF
--- a/urdf/jaguar.urdf
+++ b/urdf/jaguar.urdf
@@ -26,7 +26,7 @@
      <link name="zed2_camera_center"/>
      <joint name="zed2_camera_joint" type="fixed">
          <origin rpy="0 0 0" xyz="0.21866 0 0.34919"/>
-         <parent link="camera_frame"/>
+         <parent link="base_link"/>
          <child link="zed2_camera_center"/>
      </joint>
 </robot>


### PR DESCRIPTION
Previously, the parent link camera_frame did not exist:

https://github.com/FAIRSpace-AdMaLL/jaguar_robot/blob/510e8d708649c83e2d452c7d9e82291dd2d4b49a/urdf/jaguar.urdf#L29

I assume it's meant to be the base_link frame:
https://github.com/FAIRSpace-AdMaLL/jaguar_robot/blob/1bb9476b41536bcf7be1fc267a1d28cf5da7489e/urdf/jaguar.urdf#L29

@Marwan99  could you confirm?